### PR TITLE
Disconnect on logout.

### DIFF
--- a/events_stream.go
+++ b/events_stream.go
@@ -102,6 +102,9 @@ func (e *eventStream) listen() (connected chan bool) {
 						break
 					}
 
+					if notifyResponse.Action == "logout" {
+						e.disconnect()
+					}
 					if notifyResponse.Status == "connected" {
 						connected <- true
 					} else if notifyResponse.Status == "disconnected" {


### PR DESCRIPTION
I was getting a panic after `Login`:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x18 pc=0x633dd4]
 goroutine 35 [running]:
github.com/jeffreydwalter/arlo-golang.(*eventStream).listen.func1(0xc000172230, 0xc000186048)
        /Users/dndawso/go/src/github.com/jeffreydwalter/arlo-golang/events_stream.go:96 +0x114
created by github.com/jeffreydwalter/arlo-golang.(*eventStream).listen
        /Users/dndawso/go/src/github.com/jeffreydwalter/arlo-golang/events_stream.go:81 +0x98
```
It is caused by the `event` received on the channel being nil. I suspect this is due to the channel being closed. I also noticed the following message sent right before the nils:
```
EVENT: &{ { "action": "logout", "transId": "xxxx!XXXXXXX-XXX-XXXXXXXX","reason":"You have been logged out because you logged in from another device."} message }
```

This PR causes a disconnect if an action of "logout" is received. I don't know if this is the most desirable fix, but it works for me and my use case (a simple library downloader).  If you have other suggestions, I am all ears.

Doug.
