### PR TITLE
Update DownloadFile method to use generic http.Get()

### DIFF
--- a/util.go
+++ b/util.go
@@ -103,10 +103,12 @@ func (a *Arlo) DownloadFile(url, to string) error {
 
 func (a *Arlo) DownloadFile(url string, w io.Writer) error {
 	msg := fmt.Sprintf("failed to download file (%s)", url)
-	resp, err := a.get(url, "", nil)
+
+	resp, err := http.Get(url)
 	if err != nil {
 		return errors.WithMessage(err, msg)
 	}
+
 	defer resp.Body.Close()
 
 	_, err = io.Copy(w, resp.Body)


### PR DESCRIPTION
We do this to avoid the customised http client setting incorrect headers (which are only needed for Arlo webiste) when fetching the files from Amazon S3.

This resolves #3 where you will get 404 errors when attempting to download recordings, this (based on fairly little research) seems to stem from the fact that the request is sent with the wrong headers. Using a bare http.Get() call works perfectly.