### PR TITLE
Remove unused UnixMicro and UnixMilli functions

### DIFF
--- a/util.go
+++ b/util.go
@@ -119,22 +119,6 @@ func (a *Arlo) DownloadFile(url string, w io.Writer) error {
 	return nil
 }
 
-func UnixMicro(t time.Time) int64 {
-	ns := t.UnixNano()
-	if ns < 0 {
-		return (ns - 999) / 1000
-	}
-	return ns / 1000
-}
-
-func UnixMilli(t time.Time) int64 {
-	ns := t.UnixNano()
-	if ns < 0 {
-		return (ns - 999999) / 1000000
-	}
-	return ns / 1000000
-}
-
 func FromUnixMicro(µs int64) time.Time { return time.Unix(0, 1000*µs) }
 
 func FromUnixMilli(ms int64) time.Time { return time.Unix(0, 1000000*ms) }


### PR DESCRIPTION
As requested in #12, we want to push UnixMicro and UnixMilli to a new internal package or remove them entirely.

Searching across the repo, I cannot see that these functions are currently used for anything internally and therefore I feel they can just be removed entirely.

If I've missed a purpose for them to exist then please let me know!